### PR TITLE
#10: Step 7 (closes #10)

### DIFF
--- a/src/main/scala/rps/GameController.scala
+++ b/src/main/scala/rps/GameController.scala
@@ -1,0 +1,40 @@
+package rps
+
+import scala.concurrent.Future
+import wiro.annotation._
+import concurrent._
+import concurrent.duration._
+
+// API definition
+
+@path("rps")
+trait GameController {
+
+  @command
+  def play(
+      userMove: Move
+  ): Future[Either[Throwable, Unit]]
+
+  @query
+  def result(): Future[Either[Throwable, Match]]
+}
+
+class GameControllerImpl(gameService: GameService)(
+    implicit ecd: ExecutionContext)
+    extends GameController {
+
+  override def play(
+      userMove: Move
+  ): Future[Either[Throwable, Unit]] =
+    Future {
+      Right(
+        gameService.play(userMove)
+      )
+    }
+
+  override def result(): Future[Either[Throwable, Match]] = Future {
+    var lastGame = gameService.getLastGame()
+    lastGame.toRight(new IllegalStateException)
+  }
+
+}

--- a/src/main/scala/rps/GameRepository.scala
+++ b/src/main/scala/rps/GameRepository.scala
@@ -1,0 +1,30 @@
+package rps
+
+import Move._
+import Result._
+import Match._
+import scala.collection.concurrent.TrieMap
+
+trait GameRepository {
+
+  def saveGameOutcome(
+      theMatch: Match
+  ): Unit;
+
+  def loadGameOutcome(): Option[Match];
+}
+
+class GameRepositoryImpl() extends GameRepository {
+
+  private val memory = TrieMap.empty[String, Match]
+
+  override def saveGameOutcome(
+      theMatch: Match
+  ): Unit = {
+    memory.put("lastMatch", theMatch)
+  }
+
+  override def loadGameOutcome(): Option[Match] = {
+    memory.get("lastMatch")
+  }
+}

--- a/src/main/scala/rps/GameRepository.scala
+++ b/src/main/scala/rps/GameRepository.scala
@@ -8,10 +8,11 @@ import scala.collection.concurrent.TrieMap
 trait GameRepository {
 
   def saveGameOutcome(
+      theId: String,
       theMatch: Match
   ): Unit;
 
-  def loadGameOutcome(): Option[Match];
+  def loadGameOutcome(theId: String): Option[Match];
 }
 
 class GameRepositoryImpl() extends GameRepository {
@@ -19,12 +20,13 @@ class GameRepositoryImpl() extends GameRepository {
   private val memory = TrieMap.empty[String, Match]
 
   override def saveGameOutcome(
+      theId: String,
       theMatch: Match
   ): Unit = {
-    memory.put("lastMatch", theMatch)
+    memory.put(theId, theMatch)
   }
 
-  override def loadGameOutcome(): Option[Match] = {
-    memory.get("lastMatch")
+  override def loadGameOutcome(theId: String): Option[Match] = {
+    memory.get(theId)
   }
 }

--- a/src/main/scala/rps/GameService.scala
+++ b/src/main/scala/rps/GameService.scala
@@ -22,11 +22,11 @@ class GameServiceImpl(gameRepository: GameRepository) extends GameService {
     val computerMove = generateCPUMove()
     val outcome = computeGameOutcome(userMove, computerMove)
     val matchToBeSaved = Match(userMove, computerMove, outcome)
-    gameRepository.saveGameOutcome(matchToBeSaved)
+    gameRepository.saveGameOutcome("lastMatch", matchToBeSaved)
   }
 
   override def getLastGame(): Option[Match] = {
-    gameRepository.loadGameOutcome()
+    gameRepository.loadGameOutcome("lastMatch")
   }
 
   private def generateCPUMove(): Move = {

--- a/src/main/scala/rps/GameService.scala
+++ b/src/main/scala/rps/GameService.scala
@@ -3,39 +3,31 @@ package rps
 import Move._
 import Result._
 import io.buildo.enumero.{CaseEnumIndex, CaseEnumSerialization}
-
-import scala.concurrent.Future
 import wiro.annotation._
-import concurrent._
-import concurrent.duration._
-// API definition
 
-@path("rps")
-trait GameApi {
-  @command
+trait GameService {
+
   def play(
       userMove: Move
-  ): Future[Either[Throwable, Response]]
+  ): Unit;
+
+  def getLastGame(): Option[Match];
 }
 
-// API implementation
-class GameApiImpl()(implicit ecd: ExecutionContext) extends GameApi {
+class GameServiceImpl(gameRepository: GameRepository) extends GameService {
 
   override def play(
       userMove: Move
-  ): Future[Either[Throwable, Response]] =
-    Future {
+  ): Unit = {
+    val computerMove = generateCPUMove()
+    val outcome = computeGameOutcome(userMove, computerMove)
+    val matchToBeSaved = Match(userMove, computerMove, outcome)
+    gameRepository.saveGameOutcome(matchToBeSaved)
+  }
 
-      val computerMove = generateCPUMove()
-      val outcome = computeGameOutcome(userMove, computerMove)
-
-      Right(
-        Response(
-          userMove,
-          computerMove,
-          outcome
-        ))
-    }
+  override def getLastGame(): Option[Match] = {
+    gameRepository.loadGameOutcome()
+  }
 
   private def generateCPUMove(): Move = {
     import scala.util.Random

--- a/src/main/scala/rps/Main.scala
+++ b/src/main/scala/rps/Main.scala
@@ -29,9 +29,11 @@ object RPSServer extends App with RouterDerivationModule {
 
   implicit def throwableResponse: ToHttpResponse[Throwable] = null
 
-  val gameApiImpl = new GameApiImpl()
+  val gameRepository = new GameRepositoryImpl()
+  val gameService = new GameServiceImpl(gameRepository)
+  val gameController = new GameControllerImpl(gameService)
 
-  val gameRouter = deriveRouter[GameApi](gameApiImpl)
+  val gameRouter = deriveRouter[GameController](gameController)
 
   val rpcServer = new HttpRPCServer(
     config = Config("localhost", 8080),

--- a/src/main/scala/rps/model/Match.scala
+++ b/src/main/scala/rps/model/Match.scala
@@ -1,0 +1,3 @@
+package rps
+
+case class Match(userMove: Move, computerMove: Move, result: Result)

--- a/src/main/scala/rps/model/Response.scala
+++ b/src/main/scala/rps/model/Response.scala
@@ -1,3 +1,0 @@
-package rps
-
-case class Response(userMove: Move, computerMove: Move, result: Result)


### PR DESCRIPTION
Closes #10

## Test Plan

### tests performed

![kapture 2018-07-16 at 15 19 11](https://user-images.githubusercontent.com/1053263/42760758-bd45ea20-890b-11e8-933c-b6583796bbb8.gif)

#### Positive response
Command:

> curl -d '{"userMove":"Rock"}' -H "Content-Type: application/json" -XPOST http://localhost:8080/rps/play

Response:

```{}```

Command:

> curl  -H "Content-Type: application/json" -XGET http://localhost:8080/rps/result

Response:

```{"userMove":"Rock","computerMove":"Rock","result":"Draw"}```

### tests not performed (domain coverage)

#### Negative Response

Tests were not performed.